### PR TITLE
FIX: fix case when scroll bar is not displayed | 修复滚动条不显示时的逻辑 bug

### DIFF
--- a/ui_auto_wechat.py
+++ b/ui_auto_wechat.py
@@ -346,7 +346,8 @@ class WeChat:
         # 如果聊天记录数量 < n_msg，则继续往上翻直到满足条件或无法上翻为止
         while len(list_control.GetChildren()) < n_msg:
             # 将聊天记录翻到“查看更多消息”
-            scroll_pattern.SetScrollPercent(-1, 0)
+            if scroll_pattern:
+                scroll_pattern.SetScrollPercent(-1, 0)
             # 如果无法上翻则退出
             first_item = list_control.GetFirstChildControl()
             if self._detect_type(first_item) != 3:

--- a/ui_auto_wechat.py
+++ b/ui_auto_wechat.py
@@ -345,7 +345,7 @@ class WeChat:
 
         # 如果聊天记录数量 < n_msg，则继续往上翻直到满足条件或无法上翻为止
         while len(list_control.GetChildren()) < n_msg:
-            # 将聊天记录翻到“查看更多消息”
+            # 如果滑轮存在，将聊天记录翻到“查看更多消息”
             if scroll_pattern:
                 scroll_pattern.SetScrollPercent(-1, 0)
             # 如果无法上翻则退出


### PR DESCRIPTION
一个小 bug，当聊天框内容很少的时候微信不会显示滚动条，代码这里就会报 scroll_pattern is NoneType 的错误，需要加个判断