### PR TITLE
增加更多控件类型和新增获取指定聊天窗口的聊天记录，并按时间信息分组的功能

### DIFF
--- a/ui_auto_wechat.py
+++ b/ui_auto_wechat.py
@@ -455,6 +455,49 @@ class WeChat:
         dialogs = dialogs[::-1]
         return dialogs
 
+    def get_dialogs_by_time_blocks(self, name: str, n_time_blocks: int, search_user: bool = True) -> List[List]:
+            """
+            获取指定聊天窗口的聊天记录，并按时间信息分组。
+            Args:
+                name: 聊天窗口的姓名
+                n_time_blocks: 获取的时间分块数量
+                search_user: 是否需要搜索用户
+
+            Return:
+                groups: 聊天记录列表，每个元素为一个时间分块内的消息列表
+            """
+            n_msg = n_time_blocks * 5
+            prev_dialogs = None
+            groups = []
+            while True:
+                dialogs = self.get_dialogs(name, n_msg, search_user)
+                # 如果获取的dialogs和之前一样，说明没有更多消息了，退出循环
+                if prev_dialogs == dialogs:
+                    break
+                # 分组逻辑调整：处理顺序改为从最新消息到最早消息
+                groups = []
+                current_group = []
+
+                for msg in dialogs:
+                    if msg[0] == '时间信息':
+                        if current_group:
+                            groups.append(current_group)
+                        current_group = [msg]
+                    else:
+                        current_group.append(msg)
+                if current_group:
+                    groups.append(current_group)
+
+                # 获取n_time_blocks个时间块，取groups的最后n_time_blocks个元素
+                if len(groups) >= n_time_blocks:
+                    groups = groups[-n_time_blocks:]
+                    break
+                else:
+                    prev_dialogs = dialogs
+                    n_msg *= 2
+                    search_user = False  # 后续不需要再次搜索用户
+
+            return groups
 
 if __name__ == '__main__':
     # # 测试

--- a/ui_auto_wechat.py
+++ b/ui_auto_wechat.py
@@ -328,11 +328,15 @@ class WeChat:
             elif list_item_control.Name == "查看更多消息":
                 value = 3
             # 或者是红包信息
-            elif "红包" in list_item_control.Name or "Red packet" in list_item_control.Name:
+            elif "红包" in list_item_control.Name or "red packet" in list_item_control.Name.lower():
                 value = 2
             # 或者是撤回消息
             elif "撤回了一条消息" in list_item_control.Name:
                 value = 4
+            # 或者是新消息通知
+            elif "以下为新消息" in list_item_control.Name:
+                value = 6
+
                 
         if value is None:
             raise ValueError("无法识别该控件类型")
@@ -433,7 +437,7 @@ class WeChat:
 
         cnt = 0
         dialogs = []
-        value_to_info = {0: '用户发送', 1: '时间信息', 2: '红包信息', 3: '"查看更多消息"标志', 4: '撤回消息', 5: "System Notification"}
+        value_to_info = {0: '用户发送', 1: '时间信息', 2: '红包信息', 3: '"查看更多消息"标志', 4: '撤回消息', 5: "System Notification", 6: '"以下是新消息"标志'}
         # 从下往上依次记录聊天内容。
         for list_item_control in list_control.GetChildren()[::-1]:
             v = self._detect_type(list_item_control)

--- a/ui_auto_wechat.py
+++ b/ui_auto_wechat.py
@@ -456,48 +456,56 @@ class WeChat:
         return dialogs
 
     def get_dialogs_by_time_blocks(self, name: str, n_time_blocks: int, search_user: bool = True) -> List[List]:
-            """
-            获取指定聊天窗口的聊天记录，并按时间信息分组。
-            Args:
-                name: 聊天窗口的姓名
-                n_time_blocks: 获取的时间分块数量
-                search_user: 是否需要搜索用户
+        """
+        获取指定聊天窗口的聊天记录，并按时间信息分组。
+        Args:
+            name: 聊天窗口的姓名
+            n_time_blocks: 获取的时间分块数量
+            search_user: 是否需要搜索用户
+        Return:
+            groups: 聊天记录列表，每个元素为一个时间分块内的消息列表
+        """
+        n_msg = n_time_blocks * 5
+        prev_dialogs = None
+        groups = []
+        while True:
+            dialogs = self.get_dialogs(name, n_msg, search_user)
 
-            Return:
-                groups: 聊天记录列表，每个元素为一个时间分块内的消息列表
-            """
-            n_msg = n_time_blocks * 5
-            prev_dialogs = None
+            # 如果获取的dialogs和之前一样，说明没有更多消息了，退出循环
+            if prev_dialogs == dialogs:
+                break
+            # 分组逻辑调整：处理顺序改为从最新消息到最早消息
             groups = []
-            while True:
-                dialogs = self.get_dialogs(name, n_msg, search_user)
-                # 如果获取的dialogs和之前一样，说明没有更多消息了，退出循环
-                if prev_dialogs == dialogs:
-                    break
-                # 分组逻辑调整：处理顺序改为从最新消息到最早消息
-                groups = []
-                current_group = []
+            current_group = None
 
-                for msg in dialogs:
-                    if msg[0] == '时间信息':
-                        if current_group:
-                            groups.append(current_group)
-                        current_group = [msg]
-                    else:
-                        current_group.append(msg)
-                if current_group:
-                    groups.append(current_group)
+            # 遍历所有消息，按照时间信息分组
+            for msg in dialogs:
+                # 遇见时间信息则新建一个分组
+                if msg[0] == '时间信息':
+                    # 将上一个分组加入到groups中
+                    if current_group is not None:
+                        groups.append(current_group)
 
-                # 获取n_time_blocks个时间块，取groups的最后n_time_blocks个元素
-                if len(groups) >= n_time_blocks:
-                    groups = groups[-n_time_blocks:]
-                    break
-                else:
-                    prev_dialogs = dialogs
-                    n_msg *= 2
-                    search_user = False  # 后续不需要再次搜索用户
+                    # 初始化新的分组
+                    current_group = [msg]
 
-            return groups
+                elif current_group is not None:
+                    current_group.append(msg)
+
+            # 将最后一个分组加入到groups中
+            if current_group is not None:
+                groups.append(current_group)
+
+            # 获取n_time_blocks个时间块，取groups的最后n_time_blocks个元素
+            if len(groups) >= n_time_blocks:
+                groups = groups[-n_time_blocks:]
+                break
+            else:
+                prev_dialogs = dialogs
+                n_msg *= 2
+                search_user = False  # 后续不需要再次搜索用户
+
+        return groups
 
 if __name__ == '__main__':
     # # 测试


### PR DESCRIPTION
### 增加更多控件类型

我获取聊天记录时，发现有两个控件无法识别

_“以下是新信息”_

<img width="888" alt="image" src="https://github.com/user-attachments/assets/5fe0ed49-c6ad-4f60-9ac3-e734af6e3567">

这个控件在微信里显示的是“以下是新信息”，但在list_item_control.Name里却是"以下为新消息"，有点怪

增加了新的条件：
```
# 或者是新消息通知
elif "以下为新消息" in list_item_control.Name:
      value = 6
```

_“英文版的对方打开红包”_

<img width="856" alt="image" src="https://github.com/user-attachments/assets/631ba7b4-a0be-4d92-a199-e2f153f749da">

之前把"Red packet"加入了判断条件，但没想到微信的命名规范没统一，这次的是"Red Packet"（Packet的“P”是大写）

所以应该把控件的字母全部都转化为小写再比较

`elif "红包" in list_item_control.Name or "red packet" in list_item_control.Name.lower():
`


### 新增获取指定聊天窗口的聊天记录，并按时间信息分组的功能

在处理聊天记录时，我发现更多时候我们并不知道需要获取多少条聊天记录，而是需要获取一个时间节点的消息，如昨天的消息

所以我新增了一个方法`get_dialogs_by_time_blocks`，会以时间块来分区聊天记录，返回嵌套列表，元素是一串以时间消息分割的消息列表，例如：

```
[
[('时间信息', '', '2024年9月11日 9:01'), ('用户发送', 'Queen', '测试'), ('用户发送', 'Queen', 'hi')]
[('时间信息', '', '2024年9月12日 18:27'), ('用户发送', 'Queen', '你好')], 
[('时间信息', '', '2024年9月14日 11:01'), ('用户发送', 'Queen', '你好收到'), ('用户发送', 'Queen', '好的收到')]
]
```

这样处理聊天记录时更方便了